### PR TITLE
fix: Update how RegEx is generated so it validates correctly

### DIFF
--- a/src/PasswordValidator.php
+++ b/src/PasswordValidator.php
@@ -123,11 +123,15 @@ class PasswordValidator implements PasswordValidatorInterface
         }
 
         if ($this->excludedCharacterSet) {
-            $regEx .= sprintf('[^*%s]', $this->escapeSpecialCharacters($this->excludedCharacterSet));
+            $regEx .= sprintf('(?!.*[%s])', $this->escapeSpecialCharacters($this->excludedCharacterSet));
         }
 
-        if ($this->minimumLength || $this->maximumLength) {
-            $regEx .= sprintf('{%s,%s}', (string) $this->minimumLength, (string) $this->maximumLength);
+        if ($this->minimumLength && $this->maximumLength) {
+            $regEx .= sprintf('.{%d,%d}', $this->minimumLength, $this->maximumLength);
+        } elseif ($this->minimumLength) {
+            $regEx .= sprintf('.{%d,}', $this->minimumLength);
+        } elseif ($this->maximumLength) {
+            $regEx .= sprintf('.{0,%d}', $this->maximumLength);
         }
 
         $regEx .= '$';


### PR DESCRIPTION
GitHub Issue: # n/a

## Proposed Changes

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The regular expression can't match password properly.

## What is the new behavior?

The regular expression can match password properly.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [x] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

## Other information

n/a