### PR TITLE
ci: update workflow_run configuration for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,16 @@
 name: Release
 on:
   workflow_run:
-    workflows: [ci]
+    workflows: [CI]
     branches: [main]
+    types: [completed]
 
 jobs:
   release:
     name: Release version
     runs-on: ubuntu-latest
     environment: main
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: jblab/.github/.github/actions/release@main
         with:


### PR DESCRIPTION
GitHub Issue: n/a


## Proposed Changes

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:


## What is the current behavior?

The release workflow is triggered multiple for the CI.

## What is the new behavior?

The release workflow should be triggered only once and only if the CI succeeds.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

