### PR TITLE
ci: update release action to use app-client-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: jblab/.github/.github/actions/release@main
         with:
-          app-id: ${{ vars.GHA_BOT_APP_ID }}
+          app-client-id: ${{ vars.GHA_BOT_CLIENT_ID }}
           repository: ${{ github.repository }}
           app-private-key: ${{ secrets.GHA_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
GitHub Issue: n/a

## Proposed Changes

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build or CI related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

Switch from app-id to client-id in release action.


## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Commits have been squashed (if applicable).
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
